### PR TITLE
Fix unused variable error from pod spec lint

### DIFF
--- a/JNWSpringAnimation.m
+++ b/JNWSpringAnimation.m
@@ -123,7 +123,7 @@ static const CGFloat JNWSpringAnimationMinimumThreshold = 0.0001f;
 	NSAssert(self.fromValue != nil && self.toValue != nil, @"fromValue and or toValue must not be nil.");
 	
 	JNWValueType fromType = [self.fromValue jnw_type];
-	JNWValueType toType = [self.toValue jnw_type];
+	__unused JNWValueType toType = [self.toValue jnw_type];
 	NSAssert(fromType == toType, @"fromValue and toValue must be of the same type.");
 	NSAssert(fromType != JNWValueTypeUnknown, @"Type of value could not be determined. Please ensure the value types are supported.");
 	

--- a/JNWSpringAnimation.podspec
+++ b/JNWSpringAnimation.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "JNWSpringAnimation"
-  s.version      = "0.7"
+  s.version      = "0.7.1"
   s.summary      = "JNWSpringAnimation is a subclass of CAKeyframeAnimation that adds support for creating damped harmonic animations."
   s.homepage     = "https://github.com/jwilling/JNWSpringAnimation"
   s.license      = 'MIT'
   s.author       = { "Jonathan Willing" => "jwilling@me.com" }
-  s.source       = { :git => "https://github.com/jwilling/JNWSpringAnimation.git", :tag => "0.7" }
+  s.source       = { :git => "https://github.com/jwilling/JNWSpringAnimation.git", :tag => "0.7.1" }
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.source_files = '*.{h,m}'


### PR DESCRIPTION
@jwilling Thanks for the quick response on #7. I was checking to see whether 0.7 passed `pod spec lint` and it failed due to an unused variable error. This change should solve that problem.

To publish we'll need to merge, add a `0.7.1` tag, pass `pod spec lint`, then `pod trunk push` the updated pod spec.

Thanks again.